### PR TITLE
Fallback to string when multiplied using curly multiplier

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2410,15 +2410,15 @@ type BorderBottomWidthProperty<TLength> = Globals | BrWidth<TLength>;
 
 type BorderCollapseProperty = Globals | "collapse" | "separate";
 
-type BorderImageOutsetProperty<TLength> = Globals | TLength | number;
+type BorderImageOutsetProperty<TLength> = Globals | TLength | string | number;
 
-type BorderImageRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch";
+type BorderImageRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch" | string;
 
 type BorderImageSliceProperty = Globals | NumberPercentage | "fill" | string;
 
 type BorderImageSourceProperty = Globals | "none" | string;
 
-type BorderImageWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | number;
+type BorderImageWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | string | number;
 
 type BorderInlineEndColorProperty = Globals | Color;
 
@@ -2727,15 +2727,15 @@ type MarginTopProperty<TLength> = Globals | TLength | "auto" | string;
 
 type MaskBorderModeProperty = Globals | "alpha" | "luminance";
 
-type MaskBorderOutsetProperty<TLength> = Globals | TLength | number;
+type MaskBorderOutsetProperty<TLength> = Globals | TLength | string | number;
 
-type MaskBorderRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch";
+type MaskBorderRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch" | string;
 
 type MaskBorderSliceProperty = Globals | NumberPercentage | "fill" | string;
 
 type MaskBorderSourceProperty = Globals | "none" | string;
 
-type MaskBorderWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | number;
+type MaskBorderWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | string | number;
 
 type MaskClipProperty = Globals | GeometryBox | "no-clip" | string;
 
@@ -2813,7 +2813,7 @@ type OverflowXProperty = Globals | "auto" | "hidden" | "scroll" | "visible";
 
 type OverflowYProperty = Globals | "auto" | "hidden" | "scroll" | "visible";
 
-type OverscrollBehaviorProperty = Globals | "auto" | "contain" | "none";
+type OverscrollBehaviorProperty = Globals | "auto" | "contain" | "none" | string;
 
 type OverscrollBehaviorXProperty = Globals | "auto" | "contain" | "none";
 
@@ -3694,9 +3694,9 @@ type BgPosition<TLength> = LengthPercentage<TLength> | "bottom" | "center" | "le
 
 type LengthPercentage<TLength> = TLength | string;
 
-type RepeatStyle = "no-repeat" | "repeat" | "repeat-x" | "repeat-y" | "round" | "space";
+type RepeatStyle = "no-repeat" | "repeat" | "repeat-x" | "repeat-y" | "round" | "space" | string;
 
-type BgSize<TLength> = LengthPercentage<TLength> | "auto" | "contain" | "cover";
+type BgSize<TLength> = LengthPercentage<TLength> | "auto" | "contain" | "cover" | string;
 
 type BrStyle = "dashed" | "dotted" | "double" | "groove" | "hidden" | "inset" | "none" | "outset" | "ridge" | "solid";
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -2408,15 +2408,15 @@ type BorderBottomWidthProperty<TLength> = Globals | BrWidth<TLength>;
 
 type BorderCollapseProperty = Globals | "collapse" | "separate";
 
-type BorderImageOutsetProperty<TLength> = Globals | TLength | number;
+type BorderImageOutsetProperty<TLength> = Globals | TLength | string | number;
 
-type BorderImageRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch";
+type BorderImageRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch" | string;
 
 type BorderImageSliceProperty = Globals | NumberPercentage | "fill" | string;
 
 type BorderImageSourceProperty = Globals | "none" | string;
 
-type BorderImageWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | number;
+type BorderImageWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | string | number;
 
 type BorderInlineEndColorProperty = Globals | Color;
 
@@ -2725,15 +2725,15 @@ type MarginTopProperty<TLength> = Globals | TLength | "auto" | string;
 
 type MaskBorderModeProperty = Globals | "alpha" | "luminance";
 
-type MaskBorderOutsetProperty<TLength> = Globals | TLength | number;
+type MaskBorderOutsetProperty<TLength> = Globals | TLength | string | number;
 
-type MaskBorderRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch";
+type MaskBorderRepeatProperty = Globals | "repeat" | "round" | "space" | "stretch" | string;
 
 type MaskBorderSliceProperty = Globals | NumberPercentage | "fill" | string;
 
 type MaskBorderSourceProperty = Globals | "none" | string;
 
-type MaskBorderWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | number;
+type MaskBorderWidthProperty<TLength> = Globals | LengthPercentage<TLength> | "auto" | string | number;
 
 type MaskClipProperty = Globals | GeometryBox | "no-clip" | string;
 
@@ -2811,7 +2811,7 @@ type OverflowXProperty = Globals | "auto" | "hidden" | "scroll" | "visible";
 
 type OverflowYProperty = Globals | "auto" | "hidden" | "scroll" | "visible";
 
-type OverscrollBehaviorProperty = Globals | "auto" | "contain" | "none";
+type OverscrollBehaviorProperty = Globals | "auto" | "contain" | "none" | string;
 
 type OverscrollBehaviorXProperty = Globals | "auto" | "contain" | "none";
 
@@ -3692,9 +3692,9 @@ type BgPosition<TLength> = LengthPercentage<TLength> | "bottom" | "center" | "le
 
 type LengthPercentage<TLength> = TLength | string;
 
-type RepeatStyle = "no-repeat" | "repeat" | "repeat-x" | "repeat-y" | "round" | "space";
+type RepeatStyle = "no-repeat" | "repeat" | "repeat-x" | "repeat-y" | "round" | "space" | string;
 
-type BgSize<TLength> = LengthPercentage<TLength> | "auto" | "contain" | "cover";
+type BgSize<TLength> = LengthPercentage<TLength> | "auto" | "contain" | "cover" | string;
 
 type BrStyle = "dashed" | "dotted" | "double" | "groove" | "hidden" | "inset" | "none" | "outset" | "ridge" | "solid";
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -34,11 +34,11 @@ export enum Multiplier {
   /** Group must produce at least 1 value */
   ExclamationPoint,
   /** At least A times, at most B times */
-  QurlyBracet,
+  CurlyBracet,
 }
 
-export interface IMultiplierQurlyBracet {
-  sign: Multiplier.QurlyBracet;
+export interface IMultiplierCurlyBracet {
+  sign: Multiplier.CurlyBracet;
   min: number;
   max: number;
 }
@@ -52,7 +52,7 @@ export interface IMultiplierSimple {
     | Multiplier.ExclamationPoint;
 }
 
-export type MultiplierType = IMultiplierQurlyBracet | IMultiplierSimple;
+export type MultiplierType = IMultiplierCurlyBracet | IMultiplierSimple;
 
 export interface INonGroupData {
   entity: Entity.Component;
@@ -198,7 +198,7 @@ function multiplierData(raw: string[]): MultiplierType | null {
     case '!':
       return { sign: Multiplier.ExclamationPoint };
     case '{':
-      return { sign: Multiplier.QurlyBracet, min: +raw[1], max: +raw[2] };
+      return { sign: Multiplier.CurlyBracet, min: +raw[1], max: +raw[2] };
     default:
       return null;
   }

--- a/src/typer.ts
+++ b/src/typer.ts
@@ -9,7 +9,7 @@ import parse, {
   EntityType,
   ICombinator,
   IFunction,
-  IMultiplierQurlyBracet,
+  IMultiplierCurlyBracet,
   Multiplier,
   MultiplierType,
 } from './parser';
@@ -277,13 +277,13 @@ function isCombinator(entity: EntityType): entity is ICombinator {
   return entity.entity === Entity.Combinator;
 }
 
-function isQurlyBracetMultiplier(multiplier: MultiplierType): multiplier is IMultiplierQurlyBracet {
-  return multiplier.sign === Multiplier.QurlyBracet;
+function isCurlyBracetMultiplier(multiplier: MultiplierType): multiplier is IMultiplierCurlyBracet {
+  return multiplier.sign === Multiplier.CurlyBracet;
 }
 
 function isMultiplied(multiplier: MultiplierType) {
   return (
-    (isQurlyBracetMultiplier(multiplier) && (multiplier.min > 1 || multiplier.max === 1)) ||
+    (isCurlyBracetMultiplier(multiplier) && (multiplier.min > 1 || multiplier.max > 1)) ||
     multiplier.sign === Multiplier.Asterisk ||
     multiplier.sign === Multiplier.PlusSign ||
     multiplier.sign === Multiplier.HashMark ||
@@ -298,7 +298,7 @@ function isMandatoryCombinator({ combinator }: ICombinator) {
 function isOptionalEntity(entity: EntityType) {
   return (
     entity.multiplier &&
-    ((isQurlyBracetMultiplier(entity.multiplier) && entity.multiplier.min > 0) ||
+    ((isCurlyBracetMultiplier(entity.multiplier) && entity.multiplier.min > 0) ||
       entity.multiplier.sign === Multiplier.Asterisk ||
       entity.multiplier.sign === Multiplier.QuestionMark)
   );


### PR DESCRIPTION
Noticed that a conditional was wrong to identify if an entity is multiplied or not.