### PR TITLE
Re-implement `all` property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -301,6 +301,7 @@ export interface StandardLonghandProperties<TLength = string | 0> {
 }
 
 export interface StandardShorthandProperties<TLength = string | 0> {
+  all?: Globals;
   animation?: AnimationProperty;
   background?: BackgroundProperty<TLength>;
   border?: BorderProperty<TLength>;
@@ -811,6 +812,7 @@ export interface StandardLonghandPropertiesHyphen<TLength = string | 0> {
 }
 
 export interface StandardShorthandPropertiesHyphen<TLength = string | 0> {
+  all?: Globals;
   animation?: AnimationProperty;
   background?: BackgroundProperty<TLength>;
   border?: BorderProperty<TLength>;
@@ -1321,6 +1323,7 @@ export interface StandardLonghandPropertiesFallback<TLength = string | 0> {
 }
 
 export interface StandardShorthandPropertiesFallback<TLength = string | 0> {
+  all?: Globals | Globals[];
   animation?: AnimationProperty | AnimationProperty[];
   background?: BackgroundProperty<TLength> | BackgroundProperty<TLength>[];
   border?: BorderProperty<TLength> | BorderProperty<TLength>[];
@@ -1831,6 +1834,7 @@ export interface StandardLonghandPropertiesHyphenFallback<TLength = string | 0> 
 }
 
 export interface StandardShorthandPropertiesHyphenFallback<TLength = string | 0> {
+  all?: Globals | Globals[];
   animation?: AnimationProperty | AnimationProperty[];
   background?: BackgroundProperty<TLength> | BackgroundProperty<TLength>[];
   border?: BorderProperty<TLength> | BorderProperty<TLength>[];
@@ -2316,7 +2320,7 @@ export type SimplePseudos =
 
 export type Pseudos = AdvancedPseudos | SimplePseudos;
 
-type Globals = "inherit" | "initial" | "unset";
+type Globals = "inherit" | "initial" | "revert" | "unset";
 
 type GlobalsString = Globals | string;
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -302,6 +302,7 @@ export type StandardLonghandProperties<TLength = string | 0> = {
 };
 
 export type StandardShorthandProperties<TLength = string | 0> = {
+  all?: Globals,
   animation?: AnimationProperty,
   background?: BackgroundProperty<TLength>,
   border?: BorderProperty<TLength>,
@@ -812,6 +813,7 @@ export type StandardLonghandPropertiesHyphen<TLength = string | 0> = {
 };
 
 export type StandardShorthandPropertiesHyphen<TLength = string | 0> = {
+  all?: Globals,
   animation?: AnimationProperty,
   background?: BackgroundProperty<TLength>,
   border?: BorderProperty<TLength>,
@@ -1322,6 +1324,7 @@ export type StandardLonghandPropertiesFallback<TLength = string | 0> = {
 };
 
 export type StandardShorthandPropertiesFallback<TLength = string | 0> = {
+  all?: Globals | Globals[],
   animation?: AnimationProperty | AnimationProperty[],
   background?: BackgroundProperty<TLength> | BackgroundProperty<TLength>[],
   border?: BorderProperty<TLength> | BorderProperty<TLength>[],
@@ -1832,6 +1835,7 @@ export type StandardLonghandPropertiesHyphenFallback<TLength = string | 0> = {
 };
 
 export type StandardShorthandPropertiesHyphenFallback<TLength = string | 0> = {
+  all?: Globals | Globals[],
   animation?: AnimationProperty | AnimationProperty[],
   background?: BackgroundProperty<TLength> | BackgroundProperty<TLength>[],
   border?: BorderProperty<TLength> | BorderProperty<TLength>[],
@@ -2314,7 +2318,7 @@ export type SimplePseudos =
 
 export type Pseudos = AdvancedPseudos | SimplePseudos;
 
-type Globals = "inherit" | "initial" | "unset";
+type Globals = "inherit" | "initial" | "revert" | "unset";
 
 type GlobalsString = Globals | string;
 

--- a/src/declarator.ts
+++ b/src/declarator.ts
@@ -159,7 +159,9 @@ for (const properties of [
     let declaration: IDeclaration;
     const generics = lengthIn(types) ? [lengthGeneric] : [];
 
-    if (onlyContainsString(types)) {
+    if (types.length === 0) {
+      declaration = globalsDeclaration;
+    } else if (onlyContainsString(types)) {
       declaration = globalsAndStringDeclaration;
     } else if (onlyContainsNumber(types)) {
       declaration = globalsAndNumberDeclaration;

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -1,28 +1,26 @@
 import * as properties from 'mdn-data/css/properties.json';
 import { properties as svgData } from './data/svg';
 import parse from './parser';
-import typing, { Type, TypeType } from './typer';
+import typing, { TypeType } from './typer';
 
-const IGNORES = ['--*', 'all'];
+const IGNORES = [
+  // Custom properties
+  '--*',
+  // We define this manually
+  'all',
+];
 
 const REGEX_VENDOR_PROPERTY = /^-/;
 
-export const globals: TypeType[] = [
-  {
-    type: Type.StringLiteral,
-    literal: 'initial',
-  },
-  {
-    type: Type.StringLiteral,
-    literal: 'inherit',
-  },
-  {
-    type: Type.StringLiteral,
-    literal: 'unset',
-  },
-];
+// The CSS-wide keywords are identical to the `all` property
+// https://www.w3.org/TR/2016/CR-css-cascade-4-20160114/#all-shorthand
+export const globals: TypeType[] = typing(parse(properties.all.syntax));
+
 export const standardLonghandProperties: { [name: string]: TypeType[] } = {};
-export const standardShorthandProperties: { [name: string]: TypeType[] } = {};
+export const standardShorthandProperties: { [name: string]: TypeType[] } = {
+  // Empty so that it only receives CSS-wide keywords
+  all: [],
+};
 export const vendorPrefixedLonghandProperties: { [name: string]: TypeType[] } = {};
 export const vendorPrefixedShorthandProperties: { [name: string]: TypeType[] } = {};
 export const svgProperties: { [name: string]: TypeType[] } = {};


### PR DESCRIPTION
I can't remember why this property got ignored but i assume it was a mistake.

https://developer.mozilla.org/en-US/docs/Web/CSS/all