### PR TITLE
Add `revert` keyword to global values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2316,7 +2316,7 @@ export type SimplePseudos =
 
 export type Pseudos = AdvancedPseudos | SimplePseudos;
 
-type Globals = "inherit" | "initial" | "unset";
+type Globals = "inherit" | "initial" | "revert" | "unset";
 
 type GlobalsString = Globals | string;
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -2314,7 +2314,7 @@ export type SimplePseudos =
 
 export type Pseudos = AdvancedPseudos | SimplePseudos;
 
-type Globals = "inherit" | "initial" | "unset";
+type Globals = "inherit" | "initial" | "revert" | "unset";
 
 type GlobalsString = Globals | string;
 

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -20,6 +20,10 @@ export const globals: TypeType[] = [
     type: Type.StringLiteral,
     literal: 'unset',
   },
+  {
+    type: Type.StringLiteral,
+    literal: 'revert',
+  },
 ];
 export const standardLonghandProperties: { [name: string]: TypeType[] } = {};
 export const standardShorthandProperties: { [name: string]: TypeType[] } = {};


### PR DESCRIPTION
The `revert` keyword existed in the definitions once it relied on the values from the `all` property. But was forgotten when they was typed manually due to the fact that I couldn't find any confirmation that the `all` property and [CSS-wide keywords](https://www.w3.org/TR/css-values-3/#common-keywords) had a relationship. Now it's added again to follow the [CSS4 spec](https://www.w3.org/TR/css-cascade-4/#default).