### PR TITLE
Adding contain intrinsic size property to css type list

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1529,6 +1529,20 @@ export interface StandardLonghandProperties<TLength = (string & {}) | 0, TTime =
    */
   contentVisibility?: Property.ContentVisibility | undefined;
   /**
+   * The **`contain-intrinsic size`** CSS property controls the natural size of an element specified by content-visibility.
+   *
+   * **Syntax**: `none | <length> | auto <length>`
+   *
+   * **Initial value**: `see individual properties`
+   *
+   * | Chrome | Firefox | Safari |  Edge  | IE  |
+   * | :----: | :-----: | :----: | :----: | :-: |
+   * | **83** |   No    |   No   | **83** | No  |
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size
+   */
+  containIntrinsicSize?: Property.ContainIntrinsicSize | undefined;
+  /**
    * The **`counter-increment`** CSS property increases or decreases the value of a CSS counter by a given value.
    *
    * **Syntax**: `[ <custom-ident> <integer>? ]+ | none`

--- a/index.js.flow
+++ b/index.js.flow
@@ -100,6 +100,7 @@ export type StandardLonghandProperties<TLength = string | 0, TTime = string> = {
   contain?: Property$Contain,
   content?: Property$Content,
   contentVisibility?: Property$ContentVisibility,
+  containIntrinsicSize?: Property$ContainIntrinsicSize,
   counterIncrement?: Property$CounterIncrement,
   counterReset?: Property$CounterReset,
   counterSet?: Property$CounterSet,
@@ -1796,6 +1797,7 @@ export type StandardLonghandPropertiesFallback<TLength = string | 0, TTime = str
   contain?: Property$Contain | Array<Property$Contain>,
   content?: Property$Content | Array<Property$Content>,
   contentVisibility?: Property$ContentVisibility | Array<Property$ContentVisibility>,
+  containIntrinsicSize?: Property$ContainIntrinsicSize | Array<Property$ContainIntrinsicSize>,
   counterIncrement?: Property$CounterIncrement | Array<Property$CounterIncrement>,
   counterReset?: Property$CounterReset | Array<Property$CounterReset>,
   counterSet?: Property$CounterSet | Array<Property$CounterSet>,
@@ -4331,6 +4333,8 @@ export type Property$Contain = Globals | "content" | "layout" | "none" | "paint"
 export type Property$Content = Globals | DataType$ContentList | "none" | "normal" | string;
 
 export type Property$ContentVisibility = Globals | "auto" | "hidden" | "visible";
+
+export type Property$ContainIntrinsicSize = "none" | string | "auto";
 
 export type Property$CounterIncrement = Globals | "none" | string;
 


### PR DESCRIPTION
I am trying to add to the list of css types known by ts new feature
'contain-intrinsic-size', which is avaiable on Chrome and Internet Edge.