### PR TITLE
Fixing "The package may have incorrect main/module/exports" error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "csstype",
   "version": "3.0.11",
-  "main": "",
-  "types": "index.d.ts",
+  "main": "./index.js.flow",
+  "types": "./index.d.ts",
   "description": "Strict TypeScript and Flow types for style based on MDN data",
   "repository": "https://github.com/frenic/csstype",
   "author": "Fredrik Nicol <fredrik.nicol@gmail.com>",


### PR DESCRIPTION
Fixing error said at issue #158 where the package entry is not resolved due to miss entry point at the `package.json`. 

All tests passed. Running in a real project using vue and vite also works.