### PR TITLE
Use GitHub Actions to check that index.d.ts is not modified directly

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,31 @@
+name: 'Checks'
+on:
+  push:
+    # Only run if a generated file was modified
+    paths:
+      - index.d.ts
+      - index.js.flow
+
+jobs:
+  do_not_modify_generated_files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check if non-generated files were modified
+        id: other_files
+        uses: tj-actions/changed-files@v32
+        with:
+          files_ignore: |
+            index.d.ts
+            index.js.flow
+
+      - uses: LouisBrunner/checks-action@v1.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: 'Never modify index.d.ts and index.js.flow directly'
+          # Set status to 'success' if other files were changed,
+          # or 'failure' if only index.d.ts or index.js.flow were changed
+          conclusion: ${{ steps.other_files.outputs.any_changed == 'true' && 'success' || 'failure' }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   do_not_modify_generated_files:
+    name: 'Check which files were modifed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,3 +29,5 @@ jobs:
           # Set status to 'success' if other files were changed,
           # or 'failure' if only index.d.ts or index.js.flow were changed
           conclusion: ${{ steps.other_files.outputs.any_changed == 'true' && 'success' || 'failure' }}
+          output: |
+            {"summary":"We detected that you only modified `index.d.ts` and/or `index.js.flow`. **Never modify `index.d.ts` and `index.js.flow` directly. They are generated automatically and committed so that we can easily follow any change it results in.** You probably want to update [MDN's CSS data](https://github.com/mdn/data) or [add a patch](https://github.com/frenic/csstype/blob/master/src/data/patches.ts)."}


### PR DESCRIPTION
Adds a GitHub Actions step to check if `index.d.ts` or `index.js.flow` were modified on their own. If at least one other file was modified, the check will pass.