### PR TITLE
Patch missing shorthands for border-[inline|block]-* properties

### DIFF
--- a/src/data/patches.ts
+++ b/src/data/patches.ts
@@ -9,6 +9,42 @@ export const properties: { [property: string]: IExtendedProperty } = {
   'line-clamp': {
     shorthand: true,
   },
+  /**
+   * https://drafts.csswg.org/css-logical/#propdef-border-block-color
+   */
+  'border-block-color': {
+    shorthand: true,
+  },
+  /**
+   * https://drafts.csswg.org/css-logical/#propdef-border-inline-color
+   */
+  'border-inline-color': {
+    shorthand: true,
+  },
+  /**
+   * https://drafts.csswg.org/css-logical/#propdef-border-block-width
+   */
+  'border-block-width': {
+    shorthand: true,
+  },
+  /**
+   * https://drafts.csswg.org/css-logical/#propdef-border-inline-width
+   */
+  'border-inline-width': {
+    shorthand: true,
+  },
+  /**
+   * https://drafts.csswg.org/css-logical/#propdef-border-block-width
+   */
+  'border-block-width': {
+    shorthand: true,
+  },
+  /**
+   * https://drafts.csswg.org/css-logical/#propdef-border-inline-width
+   */
+  'border-inline-width': {
+    shorthand: true,
+  },
 };
 
 export const syntaxes: { [property: string]: MDN.Syntax } = {


### PR DESCRIPTION
As per [the CSS Logical spec](https://drafts.csswg.org/css-logical), `border-block-color`, `border-block-style`, `border-block-width`, `border-inline-color`, `border-inline-style` and `border-inline-width` are all shorthand properties.

However, they're currently showing up in the `StandardLonghandProperties` type which is incorrect:

```
export interface StandardLonghandProperties<TLength = (string & {}) | 0, TTime = string & {}> {
  // ...
  borderBlockColor?: Property.BorderBlockColor | undefined;
  // ...
}
```

 This PR aims to patch in the missing data so they are moved to the `StandardShorthandProperties` type.