### PR TITLE
remove "@types/chokidar" from devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "author": "Fredrik Nicol <fredrik.nicol@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@types/chokidar": "^2.1.3",
     "@types/css-tree": "^2.3.1",
     "@types/jest": "^29.5.0",
     "@types/jsdom": "^21.1.1",


### PR DESCRIPTION
[@types/chokidar 2.1.3](https://www.npmjs.com/package/@types/chokidar) is just a stub and provide no types.